### PR TITLE
move cardEntryDidObtainCardDetails to UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.2.2 July 23, 2019
+
+* Fixed an exception introduced in a recent Flutter update.
+
 ### v1.2.1 June 5, 2019
 
 * Added `paymentType` parameter to support apple pay pending amount configuration.

--- a/android/src/main/java/sqip/flutter/internal/CardEntryModule.java
+++ b/android/src/main/java/sqip/flutter/internal/CardEntryModule.java
@@ -81,9 +81,16 @@ final public class CardEntryModule {
     CardEntry.setCardNonceBackgroundHandler(new CardNonceBackgroundHandler() {
       @Override
       public CardEntryActivityCommand handleEnteredCardInBackground(CardDetails cardDetails) {
-        Map<String, Object> mapToReturn = cardDetailsConverter.toMapObject(cardDetails);
+        final Map<String, Object> mapToReturn = cardDetailsConverter.toMapObject(cardDetails);
         countDownLatch = new CountDownLatch(1);
-        channel.invokeMethod("cardEntryDidObtainCardDetails", mapToReturn);
+        // must be run on the UI thread to prevent an exception
+        currentActivity.runOnUiThread(
+           new Runnable() {
+            public void run() {
+              channel.invokeMethod("cardEntryDidObtainCardDetails", mapToReturn);
+            }
+          }
+        );
         try {
           // completeCardEntry or showCardNonceProcessingError must be called,
           // otherwise the thread will be leaked.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_in_app_payments
 description: An open source Flutter plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.
-version: 1.2.1
+version: 1.2.2
 author: Square Flutter Team <flutter-team@squareup.com>
 homepage: https://github.com/square/in-app-payments-flutter-plugin
 documentation: https://github.com/square/in-app-payments-flutter-plugin


### PR DESCRIPTION
## Summary

This resolves an error thrown on recent version of Flutter ("Error (Methods marked with @UiThread must be executed on the main thread)")

## Related issues

https://github.com/flutter/flutter/issues/34993
https://github.com/square/in-app-payments-flutter-plugin/issues/50

## Changelog

* Fix exception caused by method not being run on main thread
