### PR TITLE
Remove SDK build phase from example app project file

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -43,21 +43,6 @@ to make it an available resource for the Flutter library.
 
 1. Open your iOS project `Runner.xcodeproj` with **Xcode**.
 1. Set the `iOS Deployment Target` to 11.0 or above
-1. Add an In-App Payments SDK build phase:
-    1. Open the **Xcode** project for your application.
-    1. In the **Build Phases** tab for your application target, click the **+**
-        button at the top of the pane.
-    1. Select **New Run Script Phase**.
-    1. Paste the following into the editor panel of the new run script:
-        ```
-        if [ "$DEVELOPMENT_TEAM" != "" ]
-        then
-        FRAMEWORKS="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-        "${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
-        else
-        echo "Skip signing frameworks"
-        fi
-        ```
 
 
 ## Step 3: Configure the In-App Payments SDK dependency

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -163,7 +163,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CD1BB2B123A22B0C8288F229 /* [CP] Embed Pods Frameworks */,
-				11F133C72166EA0D00C242CA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -227,19 +226,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		11F133C72166EA0D00C242CA /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"$DEVELOPMENT_TEAM\" != \"\" ]\nthen\nFRAMEWORKS=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\"${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup\"\nelse\necho \"Skip sign frameworks\"\nfi\n";
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Remove SDK build phase from example app project file

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/in-app-payments-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

* removed SDK build phase from example app project file as it's no longer required after In-App Payments SDK (iOS) 1.1.1 if using Cocoapods. 

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->