### PR TITLE
set android.eableR8=false so that we use proguard instead. Fixes add …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.squareup.sqip.flutter'
-version '1.3.0'
+version '1.3.1'
 
 buildscript {
     repositories {
@@ -24,7 +24,7 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-def MIN_IAP_SDK_VERSION = '1.3.0'
+def MIN_IAP_SDK_VERSION = '1.3.1'
 def COMPILE_SDK_VERSION = 28
 def TARGET_SDK_VERSION = 28
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=false

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -30,3 +30,17 @@ target 'Runner' do
   ...
 end
 ```
+
+## I get proguard.ParseException: Use of generics not allowed for java type at '<1>_<2>_<3>JsonAdapter
+
+### The Problem
+This is a problem related to proguard and removing R8 due to it obfuscating classes our SDKS need for proper functioning. More information in: https://github.com/square/moshi/issues/738.
+
+### Solution
+
+There are a few solutions you can use:
+1. Update to a version of proguard > 6.1.0-beta2 (https://sourceforge.net/p/proguard/bugs/731/)
+2. Add `android.proguard.enableRulesExtraction=false` in your android/gradle.properties file like found in the example app.
+
+
+

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 ext {
-    sqipVersion = '1.3.0'
+    sqipVersion = '1.3.1'
 }
 
 rootProject.buildDir = '../build'

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.proguard.enableRulesExtraction=false


### PR DESCRIPTION
…card bug while allowing minification/obfuscation via proguard.

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary
This change setts using R8 to false in our plugin so that the minification and obfuscation tool is defaulted to Proguard instead of R8. There are some class files the IAP SDK needs to keep to function properly and if not kept, crash the application. 

## Related issues

Fix https://github.com/square/in-app-payments-flutter-plugin/issues/72

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/in-app-payments-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

* Upgraded to IAP 1.3.1
* Disable R8. 

## Test Plan

* Tested with flutter build apk --release and verified that on the back button on the Add card screen, the application does not crash.

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->