### PR TITLE
Increasing the plugin to version 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.7.0 March 31, 2021
+
+* Added support for null safety in Flutter 2. Many files were changed to support this, and there may be some changes required from the developer to support.
+
 ### v1.6.0 March 26, 2021
 
 * Added a new flow called [startBuyerVerificationFlow](doc/reference.md#startbuyerverificationflow) to support Strong Customer Authentication with a card-on-file card ID

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_in_app_payments
 description: An open source Flutter plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/square/in-app-payments-flutter-plugin
 documentation: https://github.com/square/in-app-payments-flutter-plugin
 


### PR DESCRIPTION
This change is accompanied by changes to support null safety in Flutter 2. This upgrade may require some changes from developers consuming the plugin as supporting null safety required various modifications.

