### PR TITLE
Creating version 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.7.1 April 20, 2021
+
+* Fixed an issue where `onAttachedToEngine` was called twice on Android, causing it to crash when the plugin `com.google.gms.google-services` was added.
+
 ### v1.7.0 March 31, 2021
 
 * Added support for null safety in Flutter 2. Many files were changed to support this, and there may be some changes required from the developer to support.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_in_app_payments
 description: An open source Flutter plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/square/in-app-payments-flutter-plugin
 documentation: https://github.com/square/in-app-payments-flutter-plugin
 


### PR DESCRIPTION
## Summary

Releasing version 1.7.1, which contains a bug fix to solve the issue where `onAttachedToEngine` is called twice when the plugin `com.google.gms.google-services` is added