### PR TITLE
Update troubleshooting.md for Flutter 2.5.0 intel-based mac workaround

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -2,6 +2,41 @@
 
 Likely causes and solutions for common problems.
 
+## I upgraded to Flutter 2.5.0 and I get a linker error on Mac
+
+### The problem
+
+You're using Flutter 2.5.0 on a Mac.When you run `flutter run`, you hit this error:
+
+```
+error: linker command failed with exit code 1 (use -v to see invocation) ld: building for iOS Simulator, but linking in dylib built for iOS
+```
+Deploying to a physical device is fine though.
+
+
+### Likely cause
+
+Flutter 2.5.0 introduced M1 support.  The In-App-Payments SDK does not have M1 support and does not allow creating builds that target arm64 simulators, resulting in the error above.
+
+### Solution
+
+Manually change your app settings to exclude arm64 simulator support.  Xcode won't try to build against this architecture so there shouldn't be any errors.
+
+**IMPORTANT NOTE:**
+**This solution will only work on intel-based macs.  M1 macs are unsupported by our SDK without any workarounds available**
+
+1.) Add the following to the bottom of your podfile:
+```
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+    config.build_settings["ONLY_ACTIVE_ARCH"] = "YES"
+  end
+end
+```
+2.) run `pod install`
+3.) You should be able to run the In-App-Payments SDK using the latest version of flutter on intel-based macs.
+
 ## I get iOS build error "While building module 'SquareInAppPaymentsSDK' imported from ..."
 
 ### The problem

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -6,7 +6,7 @@ Likely causes and solutions for common problems.
 
 ### The problem
 
-You're using Flutter 2.5.0 on a Mac.When you run `flutter run`, you hit this error:
+You're using Flutter 2.5.0 on a Mac.  When you run `flutter run`, you hit this error:
 
 ```
 error: linker command failed with exit code 1 (use -v to see invocation) ld: building for iOS Simulator, but linking in dylib built for iOS
@@ -34,7 +34,9 @@ post_install do |installer|
   end
 end
 ```
+
 2.) run `pod install`
+
 3.) You should be able to run the In-App-Payments SDK using the latest version of flutter on intel-based macs.
 
 ## I get iOS build error "While building module 'SquareInAppPaymentsSDK' imported from ..."


### PR DESCRIPTION
In flutter 2.5.0, M1 support was added and compiling makes XCode look for arm64 simulators. The IAP SDK does not support arm64 simulators and errors out.

This PR adds documentation workaround for intel-based macs.