### PR TITLE
Corrected doc links to longform docs

### DIFF
--- a/doc/enable-googlepay.md
+++ b/doc/enable-googlepay.md
@@ -146,14 +146,14 @@ class _MyAppState extends State<MyApp> {
 
 [//]: # "Link anchor definitions"
 [docs.connect.squareup.com]: https://docs.connect.squareup.com
-[In-App Payments SDK]: https://docs.connect.squareup.com/payments/readersdk/overview
+[In-App Payments SDK]: https://developer.squareup.com/docs/in-app-payments-sdk/what-it-does
 [Square Dashboard]: https://squareup.com/dashboard/
-[update policy for In-App Payments SDK]: https://docs.connect.squareup.com/payments/readersdk/overview#readersdkupdatepolicy
-[Testing Mobile Apps]: https://docs.connect.squareup.com/testing/mobile
+[update policy for In-App Payments SDK]: https://developer.squareup.com/docs/payments/readersdk/overview#readersdkupdatepolicy
+[Testing Mobile Apps]: https://developer.squareup.com/docs/testing/mobile
 [squareup.com/activate]: https://squareup.com/activate
 [Square Application Dashboard]: https://connect.squareup.com/apps/
-[In-App Payments SDK Android Setup Guide]: https://docs.connect.squareup.com/payments/readersdk/setup-android
-[In-App Payments SDK iOS Setup Guide]: https://docs.connect.squareup.com/payments/readersdk/setup-ios
+[In-App Payments SDK Android Setup Guide]: https://developer.squareup.com/docs/payments/readersdk/setup-android
+[In-App Payments SDK iOS Setup Guide]: https://developer.squareup.com/docs/payments/readersdk/setup-ios
 [root README]: ../README.md
 [Flutter Getting Started]: https://flutter.io/docs/get-started/install
 [Test Drive]: https://flutter.io/docs/get-started/test-drive


### PR DESCRIPTION
The In-App Payments overview link pointed to an old Reader SDK link.  Other doc links pointed to an older doc domain and were being redirected to https://developer.squareup.com/docs

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

Several doc links were pointing to URLs that are no longer valid and the reader was being redirected to the current URLs. Another doc link was just incorrect and pointed to the wrong topic.

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/in-app-payments-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

* message 

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->