### PR TITLE
Make `money` parameter optional in buyer verification flows

### DIFF
--- a/android/src/main/java/sqip/flutter/internal/CardEntryModule.java
+++ b/android/src/main/java/sqip/flutter/internal/CardEntryModule.java
@@ -158,7 +158,7 @@ public final class CardEntryModule {
 
   public void startCardEntryFlowWithBuyerVerification(MethodChannel.Result result, boolean collectPostalCode, String squareLocationId, String buyerActionString, Map<String, Object> moneyMap, Map<String, Object> contactMap) {
     this.squareIdentifier = new SquareIdentifier.LocationToken(squareLocationId);
-    Money money = getMoney(moneyMap);
+    Money money = moneyMap != null ? getMoney(moneyMap) : null;
     this.buyerAction = getBuyerAction(buyerActionString, money);
     this.contact = getContact(contactMap);
     this.paymentSourceId = null;
@@ -169,7 +169,7 @@ public final class CardEntryModule {
 
   public void startBuyerVerificationFlow(MethodChannel.Result result, String buyerActionString, Map<String, Object> moneyMap, String squareLocationId, Map<String, Object> contactMap, String paymentSourceId) {
     this.squareIdentifier = new SquareIdentifier.LocationToken(squareLocationId);
-    Money money = getMoney(moneyMap);
+    Money money = moneyMap != null ? getMoney(moneyMap) : null;
     this.buyerAction = getBuyerAction(buyerActionString, money);
     this.contact = getContact(contactMap);
     this.paymentSourceId = paymentSourceId;

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -139,7 +139,7 @@ onBuyerVerificationSuccess | [BuyerVerificationSuccessCallback](#BuyerVerificati
 onBuyerVerificationFailure | [BuyerVerificationErrorCallback](#BuyerVerificationErrorCallback) | Invoked when card entry with buyer verification encounters errors.
 onCardEntryCancel | [CardEntryCancelCallback](#cardentrycancelcallback) | Invoked when card entry is canceled.
 buyerAction     | string                                   | Indicates the action (`Charge` or `Store`) that will be performed onto the card after retrieving the verification token.
-money           | [Money](#Money)                          | Amount of money that will be charged
+money           | [Money](#Money)                          | **Optional.** Amount of money that will be charged. Required when `buyerAction` is `Charge`. Not used when `buyerAction` is `Store`.
 squareLocationId | string                                  | The location that is being verified against.
 contact         | [Contact](#Contact)                      | The customers information
 collectPostalCode | bool                                   | Indicates that the customer must enter the postal code associated with their payment card. When false, the postal code field will not be displayed. Defaults to `true`.<br/>**Notes**: A Postal code must be collected for processing payments for Square accounts based in the United States, Canada, and United Kingdom. Disabling postal code collection in those regions will result in all credit card transactions being declined.
@@ -314,7 +314,7 @@ Parameter       | Type                                     | Description
 onBuyerVerificationSuccess | [BuyerVerificationSuccessCallback](#BuyerVerificationSuccessCallback) | Invoked when buyer verification on a given payment source id succeeds
 onBuyerVerificationFailure | [BuyerVerificationErrorCallback](#BuyerVerificationErrorCallback) | Invoked when buyer verification on a given payment source id encouters errors
 buyerAction     | string                                   | Indicates the action (`Charge` or `Store`) that will be performed onto the card after retrieving the verification token.
-money           | [Money](#Money)                          | Amount of money that will be charged
+money           | [Money](#Money)                          | **Optional.** Amount of money that will be charged. Required when `buyerAction` is `Charge`. Not used when `buyerAction` is `Store`.
 squareLocationId | string                                  | The location that is being verified against.
 contact         | [Contact](#Contact)                      | The customers information
 paymentSourceId | string                                   | This ID can be the nonce returned by [CardEntryFlow](#startcardentryflow) or a card-on-file card ID for the buyer's payment card stored with Square.

--- a/ios/Classes/FSQIPCardEntry.m
+++ b/ios/Classes/FSQIPCardEntry.m
@@ -72,7 +72,7 @@ static NSString *const FSQIPOnBuyerVerificationErrorEventName = @"onBuyerVerific
 
 - (void)startCardEntryFlowWithVerification:(FlutterResult)result collectPostalCode:(BOOL)collectPostalCode locationId:(NSString *)locationId buyerActionString:(NSString *)buyerActionString moneyMap:(NSDictionary *)moneyMap contactMap:(NSDictionary *)contactMap
 {
-    SQIPMoney * money = [self _getMoney:moneyMap];
+    SQIPMoney * money = moneyMap != nil ? [self _getMoney:moneyMap] : nil;
     SQIPBuyerAction * buyerAction = [self _getBuyerAction:buyerActionString money:money];
     SQIPContact * contact = [self _getContact:contactMap];
 
@@ -257,7 +257,7 @@ static NSString *const FSQIPOnBuyerVerificationErrorEventName = @"onBuyerVerific
 
 - (void)startBuyerVerificationFlow:(FlutterResult)result buyerActionString:(NSString *)buyerActionString moneyMap:(NSDictionary *)moneyMap locationId:(NSString *)locationId contactMap:(NSDictionary *)contactMap paymentSourceId:(NSString *)paymentSourceId
 {
-    SQIPMoney * money = [self _getMoney:moneyMap];
+    SQIPMoney * money = moneyMap != nil ? [self _getMoney:moneyMap] : nil;
     SQIPBuyerAction * buyerAction = [self _getBuyerAction:buyerActionString money:money];
     SQIPContact * contact = [self _getContact:contactMap];
 

--- a/lib/in_app_payments.dart
+++ b/lib/in_app_payments.dart
@@ -339,21 +339,26 @@ class InAppPayments {
       required BuyerVerificationErrorCallback onBuyerVerificationFailure,
       required CardEntryCancelCallback onCardEntryCancel,
       required String buyerAction,
-      required Money money,
+      Money? money,
       required String squareLocationId,
       required Contact contact,
       bool collectPostalCode = true}) async {
+    assert(buyerAction != 'Charge' || money != null,
+        'money is required when buyerAction is "Charge"');
     _buyerVerificationSuccessCallback = onBuyerVerificationSuccess;
     _buyerVerificationErrorCallback = onBuyerVerificationFailure;
     _cardEntryCancelCallback = onCardEntryCancel;
     var params = <String, dynamic>{
       'buyerAction': buyerAction,
-      'money': _standardSerializers.serializeWith(Money.serializer, money),
       'contact':
           _standardSerializers.serializeWith(Contact.serializer, contact),
       'squareLocationId': squareLocationId,
       'collectPostalCode': collectPostalCode,
     };
+    if (money != null) {
+      params['money'] =
+          _standardSerializers.serializeWith(Money.serializer, money);
+    }
     await _channel.invokeMethod(
         'startCardEntryFlowWithBuyerVerification', params);
   }
@@ -362,20 +367,25 @@ class InAppPayments {
       {required BuyerVerificationSuccessCallback onBuyerVerificationSuccess,
       required BuyerVerificationErrorCallback onBuyerVerificationFailure,
       required String buyerAction,
-      required Money money,
+      Money? money,
       required String squareLocationId,
       required Contact contact,
       required String paymentSourceId}) async {
+    assert(buyerAction != 'Charge' || money != null,
+        'money is required when buyerAction is "Charge"');
     _buyerVerificationSuccessCallback = onBuyerVerificationSuccess;
     _buyerVerificationErrorCallback = onBuyerVerificationFailure;
     var params = <String, dynamic>{
       'buyerAction': buyerAction,
-      'money': _standardSerializers.serializeWith(Money.serializer, money),
       'contact':
           _standardSerializers.serializeWith(Contact.serializer, contact),
       'squareLocationId': squareLocationId,
       'paymentSourceId': paymentSourceId,
     };
+    if (money != null) {
+      params['money'] =
+          _standardSerializers.serializeWith(Money.serializer, money);
+    }
     await _channel.invokeMethod('startBuyerVerificationFlow', params);
   }
 


### PR DESCRIPTION
## Summary

Fixes #258

The `money` parameter in `startBuyerVerificationFlow` and `startCardEntryFlowWithBuyerVerification` is now optional (`Money?`). When `buyerAction` is `"Store"` (verifying a saved card on file rather than a charge), the native SDKs on both Android and iOS discard the money value entirely — requiring callers to construct a dummy `Money` object was unnecessary and non-intuitive.

## Problem

Both native SDKs model `BuyerAction` as a discriminated union:
- **Android**: `BuyerAction.Store()` vs `BuyerAction.Charge(money)`
- **iOS**: `[SQIPBuyerAction storeAction]` vs `[SQIPBuyerAction chargeActionWithMoney:money]`

The Flutter plugin flattened this into `String buyerAction` + `required Money money`, losing the parameter-action relationship. This forced callers using the `"Store"` action to pass a meaningless dummy:

```dart
// Before: forced to pass dummy money for Store action
await InAppPayments.startBuyerVerificationFlow(
    buyerAction: "Store",
    money: Money((b) => b..amount = 0..currencyCode = 'USD'), // unused, but required
    ...
);
```

## Reproducing steps

1. Try calling `startBuyerVerificationFlow` with `buyerAction: "Store"` and omit `money`
2. **Before this fix**: Compile error — `money` is required
3. **After this fix**: Compiles and works correctly — money is optional

## Changes

| Layer | File | Change |
|-------|------|--------|
| Dart | `lib/in_app_payments.dart` | `required Money money` → `Money? money`; added debug `assert` that money is non-null for `"Charge"`; money serialized conditionally |
| Android | `CardEntryModule.java` | Null-guard `moneyMap` before `getMoney()` in both methods |
| iOS | `FSQIPCardEntry.m` | Nil-guard `moneyMap` before `_getMoney:` in both methods |
| Docs | `doc/reference.md` | Updated parameter tables for both methods |

## After this fix

```dart
// Store action — money omitted
await InAppPayments.startBuyerVerificationFlow(
    buyerAction: "Store",
    squareLocationId: locationId,
    contact: contact,
    paymentSourceId: cardOnFileId,
    onBuyerVerificationSuccess: _onSuccess,
    onBuyerVerificationFailure: _onFailure,
);

// Charge action — money still required (enforced by assert in debug mode)
await InAppPayments.startBuyerVerificationFlow(
    buyerAction: "Charge",
    money: Money((b) => b..amount = 100..currencyCode = 'USD'),
    squareLocationId: locationId,
    contact: contact,
    paymentSourceId: nonce,
    onBuyerVerificationSuccess: _onSuccess,
    onBuyerVerificationFailure: _onFailure,
);
```

## Backwards compatibility

This is a **non-breaking** change. Existing callers passing `money` continue to compile and work unchanged.

## Test plan

- [ ] Call `startBuyerVerificationFlow` with `buyerAction: "Store"` and no `money` — should succeed on both Android and iOS
- [ ] Call `startBuyerVerificationFlow` with `buyerAction: "Charge"` and valid `money` — should succeed as before
- [ ] Call `startBuyerVerificationFlow` with `buyerAction: "Charge"` and no `money` in debug mode — should hit assert
- [ ] Same verification for `startCardEntryFlowWithBuyerVerification`