### PR TITLE
Bump IAP SDK to Android 1.6.9 / iOS 1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v1.7.14 Jul 23, 2026
+
+* Updated to IAP SDK Android to 1.6.9 and iOS to 1.6.7 — see the [IAP SDK release notes](https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-22)
+* Updated targetSdkVersion to 36
+* If your Android build fails with `2 files found with path 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'`, exclude that path in your app's `packaging` block (see the example app's `build.gradle.kts`)
+
 ### v1.7.13 Jun 4, 2026
 
 * Updated to IAP SDK iOS to 1.6.6 (Android remains on 1.6.8)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 The Flutter plugin for Square [In-App Payments SDK] is a wrapper for the native Android and iOS SDKs and 
 supports the following native In-App Payments SDK versions:
 
-  * iOS: 1.6.6
-  * Android: 1.6.8
+  * iOS: 1.6.7
+  * Android: 1.6.9
 
 ## Additional documentation
 
@@ -33,7 +33,7 @@ In addition to this README, the following is available in the [flutter plugin Gi
 ### Android
 
 * Android minSdkVersion is API 28 (Android 9). 
-* Android Target SDK version: API 35 (Android15).
+* Android Target SDK version: API 36 (Android 16).
 * Android SDK build tools: 26.0.3
 * Android Gradle Plugin: 3.0.0 or greater.
 * Support library: 27.1.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,9 +24,9 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-def MIN_IAP_SDK_VERSION = '1.6.8'
-def COMPILE_SDK_VERSION = 35
-def TARGET_SDK_VERSION = 35
+def MIN_IAP_SDK_VERSION = '1.6.9'
+def COMPILE_SDK_VERSION = 36
+def TARGET_SDK_VERSION = 36
 
 android {
     def sqipCompileSdkVersion = rootProject.hasProperty('sqipCompileSdkVersion') ? rootProject.sqipCompileSdkVersion : COMPILE_SDK_VERSION

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -30,6 +30,14 @@ android {
         versionName = flutter.versionName
     }
 
+    packaging {
+        resources {
+            // OkHttp 5.x and jspecify (transitive deps of IAP SDK 1.6.9) both ship this
+            // OSGI manifest in their multi-release jars; it is unused on Android.
+            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -4,7 +4,7 @@ platform :ios, '14.0'
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-$sqipVersion = '1.6.6'
+$sqipVersion = '1.6.7'
 
 project 'Runner', {
   'Debug' => :debug,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Flutter (1.0.0)
-  - square_in_app_payments (1.6.6):
+  - square_in_app_payments (1.6.7):
     - Flutter
-    - SquareBuyerVerificationSDK (= 1.6.6)
-    - SquareInAppPaymentsSDK (= 1.6.6)
-  - SquareBuyerVerificationSDK (1.6.6)
-  - SquareInAppPaymentsSDK (1.6.6)
+    - SquareBuyerVerificationSDK (= 1.6.7)
+    - SquareInAppPaymentsSDK (= 1.6.7)
+  - SquareBuyerVerificationSDK (1.6.7)
+  - SquareInAppPaymentsSDK (1.6.7)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  square_in_app_payments: 06fbfe68c5c4bbb354dfead8190a7e051358d4c7
-  SquareBuyerVerificationSDK: 5cea1ba9b58db082f1557adcf4087fa7b6ba862e
-  SquareInAppPaymentsSDK: 1cad924a40f39c084930478bc1021b38d70d4b61
+  square_in_app_payments: aa74685306e78d9704f2723b4dc2f4ada1a6f89e
+  SquareBuyerVerificationSDK: e4589f81dfb842c7d19134fe1d71722ae7cc8cc4
+  SquareInAppPaymentsSDK: 07eb46834e31300d27510ad3ee15940970edd327
 
-PODFILE CHECKSUM: 5bcbcc3ad323c74412ce29f4f5cf20bfc411fc2c
+PODFILE CHECKSUM: c8fdd860b4f55960a443386e2b10de33bca3d452
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/ios/square_in_app_payments.podspec
+++ b/ios/square_in_app_payments.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'square_in_app_payments'
-  s.version          = '1.6.6'
+  s.version          = '1.6.7'
   s.summary          = 'A flutter plugin for Square In-App Payments SDK.'
   s.description      = <<-DESC
 An open source Flutter plugin for calling Square's native In-App Payments SDK to take in-app payments.
@@ -24,7 +24,7 @@ An open source Flutter plugin for calling Square's native In-App Payments SDK to
     s.dependency 'SquareInAppPaymentsSDK', $sqipVersion
     s.dependency 'SquareBuyerVerificationSDK', $sqipVersion
   else
-    s.dependency 'SquareInAppPaymentsSDK', '1.6.6'
-    s.dependency 'SquareBuyerVerificationSDK', '1.6.6'
+    s.dependency 'SquareInAppPaymentsSDK', '1.6.7'
+    s.dependency 'SquareBuyerVerificationSDK', '1.6.7'
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_in_app_payments
 description: An open source Flutter plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.
-version: 1.7.13
+version: 1.7.14
 homepage: https://github.com/square/in-app-payments-flutter-plugin
 documentation: https://github.com/square/in-app-payments-flutter-plugin
 


### PR DESCRIPTION
Updates the Flutter plugin to IAP SDK Android 1.6.9 and iOS 1.6.7. See the [IAP SDK release notes](https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-22).

- `MIN_IAP_SDK_VERSION` `1.6.8` -> `1.6.9` in `android/build.gradle`
- `compileSdk` / `targetSdk` bumped to 36 (matching the SDK's new target API level) in both the plugin and the example app
- `SquareInAppPaymentsSDK` / `SquareBuyerVerificationSDK` `1.6.6` -> `1.6.7` in the podspec
- Example app Podfile pin bumped to `1.6.7` with `Podfile.lock` regenerated via `pod install`
- Plugin version bumped to `1.7.14` with a changelog entry
- README supported-versions list updated

## Note on packaging exclude

IAP SDK 1.6.9 pulls in OkHttp 5.x, whose multi-release jars (`logging-interceptor`, `jspecify`) both ship `META-INF/versions/9/OSGI-INF/MANIFEST.MF`, which breaks `mergeDebugJavaResource` with a duplicate-file error. Added a `packaging` exclude for it in the example app and documented the workaround in the changelog since integrators will hit the same thing.

Verified with `flutter build apk --debug` on the example app — builds green with all IAP deps resolved at 1.6.9 / Netcetera 2.6.0.0.